### PR TITLE
Some upcoming event display summaries are getting chomped. 

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -30,7 +30,7 @@
                 event.badgeStart = true;
             }
             event.momentjs = start;
-            event.organiser = event.summaryDisplay.slice(0, event.summaryDisplay.lastIndexOf(event.summary) - 2);
+            event.organiser = event.summaryDisplay.slice(0, event.summaryDisplay.lastIndexOf(event.summary)).replace(/:\s+$/g,'');
             if (event.description.length > 200) {
                 var short = event.description.substring(0, 200);
                 event.short = short.substring(0, short.lastIndexOf(' ')) + '...';


### PR DESCRIPTION
The current upcoming events list is showing "Diversity CFP Worksh" and "Sheffield Refugee Hackath".

There is some code that subtracts 2 from the `event.organiser` in an attempt to remove a trailing colon-space. Not all events have this though, so this change uses a regex replace to only remove those chars if they exist.