### PR TITLE
updated gulp deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
   "author": "Laura Kishimoto <hello@laurakishimoto.com> (https://github.com/chicgeek)",
   "devDependencies": {
     "gulp": "^3.9.1",
-    "gulp-load-plugins": "^1.2.0",
+    "gulp-load-plugins": "^1.5.0",
     "gulp-remarkable": "^1.1.2",
     "gulp-rename": "^1.2.2",
-    "gulp-replace": "^0.5.4",
-    "gulp-sass": "^2.2.0",
-    "gulp-sourcemaps": "^1.6.0",
-    "gulp-wrap": "^0.11.0"
+    "gulp-replace": "^0.6.1",
+    "gulp-sass": "^3.1.0",
+    "gulp-sourcemaps": "^2.6.1",
+    "gulp-wrap": "^0.13.0"
   }
 }


### PR DESCRIPTION
Original version of node-sass doesn't work with nodejs 8+.
Updated deps to latest and checked `install` + `npm run build` with node 6.9.0 and 8.9.1.