### PR TITLE
Update Gulp deps and add SheffieldML

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@ Powered By <a href="http://ican.hasacalendar.co.uk/">Has A Calendar</a></p>
 <li><a href="http://www.sheffielddevops.org.uk/">Sheffield Devops</a> - 2nd thursday</li>
 <li><a href="https://groups.google.com/forum/?hl=en&amp;fromgroups=#!forum/opendatasheffield">Open Data Sheffield</a> - 3rd monday</li>
 <li><a href="https://twitter.com/sheffieldswift">SheffieldSwift</a> - 3rd tuesday</li>
+<li><a href="https://twitter.com/shef_ml">SheffieldML</a> - 3rd tuesday</li>
 <li><a href="http://www.meetup.com/Startup-Sheffield/">Startup in the pub</a> - 3rd wednesday</li>
 <li><a href="http://twitter.com/tidalclub">Tidal Club</a> - 3rd Thursday</li>
 <li><a href="http://www.mathsjam.com/index.php?city=sheffield">MathsJam Sheffield</a> - second to last tuesday</li>

--- a/index.md
+++ b/index.md
@@ -49,6 +49,7 @@ Powered By [Has A Calendar](http://ican.hasacalendar.co.uk/)
 * [Sheffield Devops](http://www.sheffielddevops.org.uk/) - 2nd thursday
 * [Open Data Sheffield](https://groups.google.com/forum/?hl=en&fromgroups=#!forum/opendatasheffield) - 3rd monday
 * [SheffieldSwift](https://twitter.com/sheffieldswift) - 3rd tuesday
+* [SheffieldML](https://twitter.com/shef_ml) - 3rd tuesday
 * [Startup in the pub](http://www.meetup.com/Startup-Sheffield/) - 3rd wednesday
 * [Tidal Club](http://twitter.com/tidalclub) - 3rd Thursday
 * [MathsJam Sheffield](http://www.mathsjam.com/index.php?city=sheffield) - second to last tuesday

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
   "author": "Laura Kishimoto <hello@laurakishimoto.com> (https://github.com/chicgeek)",
   "devDependencies": {
     "gulp": "^3.9.1",
-    "gulp-load-plugins": "^1.2.0",
+    "gulp-load-plugins": "^1.5.0",
     "gulp-remarkable": "^1.1.2",
     "gulp-rename": "^1.2.2",
-    "gulp-replace": "^0.5.4",
-    "gulp-sass": "^2.2.0",
-    "gulp-sourcemaps": "^1.6.0",
-    "gulp-wrap": "^0.11.0"
+    "gulp-replace": "^0.6.1",
+    "gulp-sass": "^3.1.0",
+    "gulp-sourcemaps": "^2.6.1",
+    "gulp-wrap": "^0.13.0"
   }
 }


### PR DESCRIPTION
Includes gulp version updates - node-sass doesn't work with Node 8+