### PR TITLE
fix(events): filter out cancelled events from the calendar feed

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@ for this page and send a pull request.</p>
 <script src="/js/lodash.custom.min.js"></script>
 <script type="text/lodash-template" id="calendar-template">
 <% if (events.length) { %>
-    <% events.forEach(function(event) { %>
+    <% events.filter(event => !event.cancelled).forEach(function(event) { %>
         <div class="event" id="event<%- event._id %>">
             <h4 class="organiser">
                 <%- event.organiser %>


### PR DESCRIPTION
This is a super basic response to the issue @mbooth101 raised in IRC, which removes cancelled events from the calendar.

Potential improvements could be applying a badge of some kind to mark that it _was_ happening, but is no longer, in the same way opentechcalendar does, i.e. https://opentechcalendar.co.uk/event/6515-no-more-working-in-the-dark-1-of-2