### PR TITLE
Adding CodeUp Sheffield to Meatspace Meetups

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@ Powered By <a href="http://ican.hasacalendar.co.uk/">Has A Calendar</a></p>
 <li><a href="http://shrug.org/">Sheffield Ruby User Group (ShRUG)</a> - 2nd Monday</li>
 <li><a href="http://wpsheffield.com/">WordPress Sheffield</a> - 2nd Tuesday</li>
 <li><a href="http://defshef.github.io">(def shef)</a> - 2nd Tuesday</li>
-<li><a href="https://sheffield.openrightsgroup.org/">Open Rights Group</a> - 2nd Wednesday</li>
+<li><a href="https://www.meetup.com/CodeUp-Sheffield/">CodeUp Sheffield</a> - 2nd Wednesday</li>
 <li><a href="http://www.sheffielddevops.org.uk/">Sheffield Devops</a> - 2nd Thursday</li>
 <li><a href="https://groups.google.com/forum/?hl=en&amp;fromgroups=#!forum/opendatasheffield">Open Data Sheffield</a> - 3rd Monday</li>
 <li><a href="https://twitter.com/sheffieldswift">SheffieldSwift</a> - 3rd Tuesday</li>

--- a/index.md
+++ b/index.md
@@ -46,7 +46,7 @@ Powered By [Has A Calendar](http://ican.hasacalendar.co.uk/)
 * [Sheffield Ruby User Group (ShRUG)](http://shrug.org/) - 2nd Monday
 * [WordPress Sheffield](http://wpsheffield.com/) - 2nd Tuesday
 * [(def shef)](http://defshef.github.io) - 2nd Tuesday
-* [Open Rights Group](https://sheffield.openrightsgroup.org/) - 2nd Wednesday
+* [CodeUp Sheffield](https://www.meetup.com/CodeUp-Sheffield/) - 2nd Wednesday
 * [Sheffield Devops](http://www.sheffielddevops.org.uk/) - 2nd Thursday
 * [Open Data Sheffield](https://groups.google.com/forum/?hl=en&fromgroups=#!forum/opendatasheffield) - 3rd Monday
 * [SheffieldSwift](https://twitter.com/sheffieldswift) - 3rd Tuesday


### PR DESCRIPTION
Changed the 2nd Wednesday of the month Meatspace meetup from ORG to CodeUp. Fixed #34.