### PR TITLE
add a section of inactive meetups

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,27 +110,30 @@ Powered By <a href="http://ican.hasacalendar.co.uk/">Has A Calendar</a></p>
 <li><a href="http://defshef.github.io">(def shef)</a> - 2nd Tuesday</li>
 <li><a href="https://www.meetup.com/CodeUp-Sheffield/">CodeUp Sheffield</a> - 2nd Wednesday</li>
 <li><a href="http://www.sheffielddevops.org.uk/">Sheffield Devops</a> - 2nd Thursday</li>
-<li><a href="https://groups.google.com/forum/?hl=en&amp;fromgroups=#!forum/opendatasheffield">Open Data Sheffield</a> - 3rd Monday</li>
 <li><a href="https://twitter.com/sheffieldswift">SheffieldSwift</a> - 3rd Tuesday</li>
 <li><a href="https://twitter.com/shef_ml">SheffieldML</a> - 3rd Tuesday</li>
-<li><a href="http://www.meetup.com/Startup-Sheffield/">Startup in the pub</a> - 3rd Wednesday</li>
 <li><a href="http://shrug.org/">Sheffield Ruby User Group (ShRUG)</a> - 3rd Wednesday</li>
 <li><a href="http://twitter.com/tidalclub">Tidal Club</a> - 3rd Thursday</li>
 <li><a href="https://www.bcs.org/category/18932">BCS South Yorkshire</a> - 3rd Thursday (Sept - Apr)</li>
-<li><a href="http://www.mathsjam.com/index.php?city=sheffield">MathsJam Sheffield</a> - second to last Tuesday</li>
 <li><a href="http://www.sheffieldhardwarehackers.org.uk/">Sheffield Hackspace</a> - open evenings every Friday</li>
 <li><a href="https://twitter.com/pysheff">Python Sheffield</a> - last Tuesday</li>
 <li><a href="http://www.meetup.com/SheffieldR-Sheffield-R-Users-Group/">SheffieldR</a> - last Tuesday</li>
 <li><a href="http://www.meetup.com/Agile-Sheffield-Meetup/">Agile Sheffield</a> - last Wednesday</li>
 <li><a href="https://twitter.com/FrontEndSheff">Front End Sheffield</a> - last Thursday</li>
-<li><a href="https://www.owasp.org/index.php/Sheffield">OWASP Sheffield</a></li>
 <li><a href="http://twitter.com/uxsheffield">UX Sheffield</a></li>
 <li><a href="https://www.sheffieldphp.co.uk/">Sheffield PHP</a></li>
-<li><a href="http://dorkbotsheffield.lurk.org/">Dorkbot Sheffield</a></li>
 <li><a href="http://www.meetup.com/Sheffield-Test-Gathering">Sheffield Test Gathering</a></li>
 <li><a href="http://www.sheflug.org.uk">Sheffield Linux User Group</a> - usually 1st or 2nd Saturday</li>
 <li><a href="https://opentechcalendar.co.uk/group/477-queer-code-yorkshire">Queer Code Yorkshire</a> - ad-hoc, Leeds and Sheffield</li>
 <li><a href="https://www.meetup.com/AWSSheffield/">AWS Sheffield</a> - every 2 months</li>
+</ul>
+<h4 id="currently-inactive">Currently inactive</h4>
+<ul>
+<li><a href="https://groups.google.com/forum/?hl=en&amp;fromgroups=#!forum/opendatasheffield">Open Data Sheffield</a> - inactive since 2015</li>
+<li><a href="http://www.meetup.com/Startup-Sheffield/">Startup in the pub</a> - inactive since 2016</li>
+<li><a href="http://www.mathsjam.com/index.php?city=sheffield">MathsJam Sheffield</a> - inactive since 2017</li>
+<li><a href="https://www.owasp.org/index.php/Sheffield">OWASP Sheffield</a> - inactive since 2018</li>
+<li><a href="http://dorkbotsheffield.lurk.org/">Dorkbot Sheffield</a> - inactive since 2018</li>
 </ul>
 </div>
 </div>

--- a/index.md
+++ b/index.md
@@ -47,27 +47,30 @@ Powered By [Has A Calendar](http://ican.hasacalendar.co.uk/)
 * [(def shef)](http://defshef.github.io) - 2nd Tuesday
 * [CodeUp Sheffield](https://www.meetup.com/CodeUp-Sheffield/) - 2nd Wednesday
 * [Sheffield Devops](http://www.sheffielddevops.org.uk/) - 2nd Thursday
-* [Open Data Sheffield](https://groups.google.com/forum/?hl=en&fromgroups=#!forum/opendatasheffield) - 3rd Monday
 * [SheffieldSwift](https://twitter.com/sheffieldswift) - 3rd Tuesday
 * [SheffieldML](https://twitter.com/shef_ml) - 3rd Tuesday
-* [Startup in the pub](http://www.meetup.com/Startup-Sheffield/) - 3rd Wednesday
 * [Sheffield Ruby User Group (ShRUG)](http://shrug.org/) - 3rd Wednesday
 * [Tidal Club](http://twitter.com/tidalclub) - 3rd Thursday
 * [BCS South Yorkshire](https://www.bcs.org/category/18932) - 3rd Thursday (Sept - Apr)
-* [MathsJam Sheffield](http://www.mathsjam.com/index.php?city=sheffield) - second to last Tuesday
 * [Sheffield Hackspace](http://www.sheffieldhardwarehackers.org.uk/) - open evenings every Friday
 * [Python Sheffield](https://twitter.com/pysheff) - last Tuesday
 * [SheffieldR](http://www.meetup.com/SheffieldR-Sheffield-R-Users-Group/) - last Tuesday
 * [Agile Sheffield](http://www.meetup.com/Agile-Sheffield-Meetup/) - last Wednesday
 * [Front End Sheffield](https://twitter.com/FrontEndSheff) - last Thursday
-* [OWASP Sheffield](https://www.owasp.org/index.php/Sheffield)
 * [UX Sheffield](http://twitter.com/uxsheffield)
 * [Sheffield PHP](https://www.sheffieldphp.co.uk/)
-* [Dorkbot Sheffield](http://dorkbotsheffield.lurk.org/)
 * [Sheffield Test Gathering](http://www.meetup.com/Sheffield-Test-Gathering)
 * [Sheffield Linux User Group](http://www.sheflug.org.uk) - usually 1st or 2nd Saturday
 * [Queer Code Yorkshire](https://opentechcalendar.co.uk/group/477-queer-code-yorkshire) - ad-hoc, Leeds and Sheffield
 * [AWS Sheffield](https://www.meetup.com/AWSSheffield/) - every 2 months
+
+#### Currently inactive
+
+* [Open Data Sheffield](https://groups.google.com/forum/?hl=en&fromgroups=#!forum/opendatasheffield) - inactive since 2015
+* [Startup in the pub](http://www.meetup.com/Startup-Sheffield/) - inactive since 2016
+* [MathsJam Sheffield](http://www.mathsjam.com/index.php?city=sheffield) - inactive since 2017
+* [OWASP Sheffield](https://www.owasp.org/index.php/Sheffield) - inactive since 2018
+* [Dorkbot Sheffield](http://dorkbotsheffield.lurk.org/) - inactive since 2018
 
 --ENDCOL
 --ENDROW


### PR DESCRIPTION
All of these haven't had events or any activity for at least a year.

Add a new section, so that they're not removed entirely. Some of them
are simply looking for new organisers, for example.

The new content shows as a sub-section under "Meatspace meetups".