### PR TITLE
removes CodeUp Sheffield from Meatspace meetups list

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,6 @@ Powered By <a href="http://ican.hasacalendar.co.uk/">Has A Calendar</a></p>
 <li><a href="https://www.meetup.com/GoSheffield/">GoSheffield</a> - 1st Thursday</li>
 <li><a href="http://wpsheffield.com/">WordPress Sheffield</a> - 2nd Tuesday</li>
 <li><a href="https://defshef.github.io">(def shef)</a> - 2nd Tuesday</li>
-<li><a href="https://www.meetup.com/CodeUp-Sheffield/">CodeUp Sheffield</a> - 2nd Wednesday</li>
 <li><a href="https://www.sheffielddevops.org.uk/">Sheffield Devops</a> - 2nd Thursday</li>
 <li><a href="https://twitter.com/sheffieldswift">SheffieldSwift</a> - 3rd Tuesday</li>
 <li><a href="https://twitter.com/shef_ml">SheffieldML</a> - 3rd Tuesday</li>

--- a/index.md
+++ b/index.md
@@ -51,7 +51,6 @@ Powered By [Has A Calendar](http://ican.hasacalendar.co.uk/)
 * [GoSheffield](https://www.meetup.com/GoSheffield/) - 1st Thursday
 * [WordPress Sheffield](http://wpsheffield.com/) - 2nd Tuesday
 * [(def shef)](https://defshef.github.io) - 2nd Tuesday
-* [CodeUp Sheffield](https://www.meetup.com/CodeUp-Sheffield/) - 2nd Wednesday
 * [Sheffield Devops](https://www.sheffielddevops.org.uk/) - 2nd Thursday
 * [SheffieldSwift](https://twitter.com/sheffieldswift) - 3rd Tuesday
 * [SheffieldML](https://twitter.com/shef_ml) - 3rd Tuesday


### PR DESCRIPTION
CodeUp is closing down and CodeUp Sheffield has had its last meeting. (A new organisation, CodeWith, has been created to take CodeUp's place, but no plans have been made yet for local, Meatspace meetups. If that happens, I'll be back with another PR.)